### PR TITLE
Now HDID bans and IP bans work, Plus logging.

### DIFF
--- a/server/ban_manager.py
+++ b/server/ban_manager.py
@@ -24,6 +24,8 @@ class BanManager:
     def __init__(self):
         self.bans = []
         self.load_banlist()
+        self.hdidbans = []
+        self.load_hdidbanlist()
 
     def load_banlist(self):
         try:
@@ -32,30 +34,26 @@ class BanManager:
         except FileNotFoundError:
             return
 
+    def load_hdidbanlist(self):
+        try:
+            with open('storage/hdidbanlist.json', 'r') as hdidbanlist_file:
+                self.hdidbans = json.load(hdidbanlist_file)
+        except FileNotFoundError:
+            return
+
     def write_banlist(self):
         with open('storage/banlist.json', 'w') as banlist_file:
             json.dump(self.bans, banlist_file)
+
+    def write_hdidbanlist(self):
+        with open('storage/hdidbanlist.json', 'w') as hdidbanlist_file:
+            json.dump(self.hdidbans, hdidbanlist_file)
 
     def add_ban(self, ip):
         if ip not in self.bans:
             self.bans.append(ip)
         else:
             raise ServerError('This IP is already banned.')
-        self.write_banlist()
-
-    def add_hdidban(self, hdid):
-        if hdid not in self.bans:
-            self.bans.append(hdid)
-        else:
-            raise ServerError('This HDID is already banned.')
-        self.write_banlist()
-			
-    def add_hdidipban (self, hdid, ip):
-        if hdid and ip not in self.bans:
-            self.bans.append(hdid)
-            self.bans.append(ip)
-        else:
-            raise ServerError('This IP or HDID is already banned.')
         self.write_banlist()
 
     def remove_ban(self, ip):
@@ -65,8 +63,15 @@ class BanManager:
             raise ServerError('This IP is not banned.')
         self.write_banlist()
 
+    def add_hdidban(self, hdid):
+        if hdid not in self.hdidbans:
+            self.hdidbans.append(hdid)
+        else:
+            raise ServerError('This HDID is already banned.')
+        self.write_hdidbanlist()
+
     def is_banned(self, ip):
         return ip in self.bans
-	
+
     def is_hdidbanned(self, hdid):
-        return hdid in self.bans
+        return hdid in self.hdidbans

--- a/server/ban_manager.py
+++ b/server/ban_manager.py
@@ -63,6 +63,13 @@ class BanManager:
             raise ServerError('This IP is not banned.')
         self.write_banlist()
 
+    def remove_hdidban(self, hdid):
+        if hdid in self.hdidbans:
+            self.hdidbans.remove(hdid)
+        else:
+            raise ServerError('This HDID is not banned.')
+        self.write_hdidbanlist()
+
     def add_hdidban(self, hdid):
         if hdid not in self.hdidbans:
             self.hdidbans.append(hdid)

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -319,11 +319,13 @@ class ClientManager:
     def get_hdid_by_ip(self, ip):
         clients = []
         for client in self.clients:
-            if client.get_hdid() != None:
+	    hdid = client.get_hdid()
+            if client.get_hdid() != None and client.get_ip() == ip:
                 clients.append(client)
+		return hdid
 		    else
                         return None
-	return clients
+	return None
 
     def get_muted_clients(self):
         clients = []

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -212,6 +212,18 @@ class ClientManager:
         def get_hdid(self):
             return self.hdid
 
+        def get_area_info(self, area_id):
+            info = ''
+            try:
+                area = self.server.area_manager.get_area_by_id(area_id)
+            except AreaError:
+                raise
+            info += '= Area {}: {} =='.format(area.id, area.name)
+            sorted_clients = sorted(area.clients, key=lambda x: x.get_char_name())
+            for c in sorted_clients:
+                info += '\r\n{}'.format(c.get_char_name())
+            return info
+
         def get_area_hdid(self, area_id):
             info = ''
             try:
@@ -276,23 +288,14 @@ class ClientManager:
             if client.get_ip() == ip:
                 clients.append(client)
         return clients
-	
+
     def get_targets_by_hdid(self, hdid):
         clients = []
         for client in self.clients:
             if client.get_hdid() == hdid:
                 clients.append(client)
-            return clients
-
-    def get_targets_by_hdidip(self, hdid, ip):
-        clients = []
-        for client in self.clients:
-            if client.get_ip() == ip:
-                clients.append(client)
-            if client.get_hdid() == hdid:
-                clients.append(client)
         return clients
-		
+
     def get_targets_by_ooc_name(self, name):
         clients = []
         for client in self.clients:
@@ -316,17 +319,6 @@ class ClientManager:
             return ooc
         return None
 
-    def get_hdid_by_ip(self, ip):
-        clients = []
-        for client in self.clients:
-	    hdid = client.get_hdid()
-            if client.get_hdid() != None and client.get_ip() == ip:
-                clients.append(client)
-		return hdid
-		    else
-                        return None
-	return None
-
     def get_muted_clients(self):
         clients = []
         for client in self.clients:
@@ -340,3 +332,27 @@ class ClientManager:
             if client.is_ooc_muted:
                 clients.append(client)
         return clients
+
+    def get_hdid_by_ip(self, ip):
+        for client in self.clients:
+            hdid = client.get_hdid()
+            for client in self.clients:
+                if client.get_hdid() is not None and client.get_ip() == ip:
+                    hdid = client.get_hdid()
+                    return hdid
+        if hdid == None:
+            return None
+        else:
+            return hdid
+
+    def get_ip_by_hdid(self, hdid):
+        for client in self.clients:
+            ip = client.get_ip()
+            for client in self.clients:
+                if client.get_ip() is not None and client.get_hdid() == hdid:
+                    ip = client.get_ip()
+                    return ip
+        if ip == None:
+            return None
+        else:
+            return ip

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -316,6 +316,15 @@ class ClientManager:
             return ooc
         return None
 
+    def get_hdid_by_ip(self, ip):
+        clients = []
+        for client in self.clients:
+            if client.get_hdid() != None:
+                clients.append(client)
+		    else
+                        return None
+	return clients
+
     def get_muted_clients(self):
         clients = []
         for client in self.clients:

--- a/server/commands.py
+++ b/server/commands.py
@@ -402,20 +402,17 @@ def ooc_cmd_ban(client, arg):
     ip = arg.strip()
     if len(ip) < 7:
         raise ArgumentError('You must specify an IP.')
-    hdid = arg.strip()
-    if len(hdid) < 8:
-        raise ArgumentError('You must specify a HDID.')
     try:
-        client.server.ban_manager.add_hdidipban(hdid, ip)
+        client.server.ban_manager.add_ban(ip)
     except ServerError:
         raise
-    targets = client.server.client_manager.get_targets_by_hdidip(ip, hdid)
+    targets = client.server.client_manager.get_targets_by_ip(ip)
     if targets:
         for c in targets:
             c.disconnect()
         client.send_host_message('Kicked {} existing client(s).'.format(len(targets)))
-    client.send_host_message('Added {} to the banlist.'.format(ip, hdid))
-    logger.log_server('Banned {}.'.format(ip, hdid), client)
+    client.send_host_message('Added {} to the banlist.'.format(ip))
+    logger.log_server('Banned {}.'.format(ip), client)
 
 def ooc_cmd_unban(client, arg):
     if not client.is_mod:
@@ -428,7 +425,7 @@ def ooc_cmd_unban(client, arg):
     except ServerError:
         raise
     logger.log_server('Unbanned {}.'.format(ip), client)
-	
+
 def ooc_cmd_getip(client, arg):
 	if not client.is_mod:
 		raise ClientError ('You must be authorized to do that.')
@@ -460,33 +457,7 @@ def ooc_cmd_gethdids(client, arg):
 	if len(arg) != 0:
 		raise ArgumentError('This command takes no arguments.')
 	client.send_all_area_hdid()
-
-def ooc_cmd_hdid(client, arg):
-	if not client.is_mod:
-		raise ClientError('You must be authorized to do that.')
-	if len(arg) == 0 and client.is_mod:
-		raise ArgumentError('You must specify a HDID.')
-	if client.is_mod:
-			args = arg.split()
-			msg = ' '.join(args[1:])
-			for char_name in client.server.char_list:
-				if arg.lower().startswith(char_name.lower()):
-					char_len = len(char_name.split())
-					to_search = ' '.join(args[:char_len])
-					try:
-						c = client.area.get_target_by_char_name(to_search)
-					except AreaError:
-						raise
-			if not c:
-				c = client.server.client_manager.get_targets(client, args[0])
-			if not c:
-				c = client.server.client_manager.get_targets_by_ip(client, args[0])
-			if not c:
-				client.send_host_message('No targets found.')
-			else:
-				info = 'Target HD ID: {}'.format(c.get_hdid())
-				client.send_host_message(info)
-				
+			
 def ooc_cmd_play(client, arg):
     if not client.is_mod:
         raise ClientError('You must be authorized to do that.')
@@ -646,3 +617,55 @@ def ooc_cmd_mutepm(client, arg):
         client.send_host_message('You stopped receiving PMs')
     else:
         client.send_host_message('You are now receiving PMs')
+
+def ooc_cmd_ban(client, arg):
+    if not client.is_mod:
+        raise ClientError('You must be authorized to do that.')
+    ip = arg.strip()
+    if len(ip) < 7:
+        raise ArgumentError('You must specify a valid IP.')
+    try:
+        client.server.ban_manager.add_ban(ip)
+    except ServerError:
+        raise
+    hdid = client.server.client_manager.get_hdid_by_ip(ip)
+    if hdid == None:
+        client.send_host_message('Unable to locate client HDID for logging.')
+    targets = client.server.client_manager.get_targets_by_ip(ip)
+    if targets:
+        for c in targets:
+            c.disconnect()
+        client.send_host_message('Kicked {} existing client(s).'.format(len(targets)))
+    if hdid != None:
+        client.send_host_message('Added {} to the banlist.'.format(ip))
+        logger.log_server('Banned {}, {} at IP.'.format(ip, hdid), client)
+    else:
+        client.send_host_message('Added {} to the banlist.'.format(ip))
+        logger.log_server('Banned {} at IP. Could not locate client HDID.'.format(ip, hdid), client)
+
+def ooc_cmd_banhdid(client, arg):
+    if not client.is_mod:
+        raise ClientError('You must be authorized to do that.')
+    hdid = arg.strip()
+    if len(hdid) < 8:
+        raise ArgumentError('You must specify a valid HDID.')
+    try:
+        client.server.ban_manager.add_hdidban(hdid)
+    except ServerError:
+        raise
+    ip = client.server.client_manager.get_ip_by_hdid(hdid)
+    if ip == None:
+        client.send_host_message('Unable to locate client IP for logging.')
+    else:
+        client.server.ban_manager.add_ban(ip)
+    targets = client.server.client_manager.get_targets_by_hdid(hdid)
+    if targets:
+        for c in targets:
+            c.disconnect()
+        client.send_host_message('Kicked {} existing client(s).'.format(len(targets)))
+    if hdid != None:
+        client.send_host_message('Added {} to the banlist.'.format(hdid))
+        logger.log_server('Banned {}, {} at HDID.'.format(ip, hdid), client)
+    else:
+        client.send_host_message('Added {} to the banlist.'.format(hdid))
+        logger.log_server('Banned {} at HDID. Could not locate client ip.'.format(ip, hdid), client)

--- a/server/commands.py
+++ b/server/commands.py
@@ -425,6 +425,20 @@ def ooc_cmd_unban(client, arg):
     except ServerError:
         raise
     logger.log_server('Unbanned {}.'.format(ip), client)
+    client.send_host_message('Unbanned {}'.format(ip))
+
+def ooc_cmd_unbanhdid(client, arg):
+    if not client.is_mod:
+        raise ClientError('You must be authorized to do that.')
+    hdid = arg.strip()
+    if len(hdid) < 8:
+        raise ArgumentError('You must specify a valid HDID.')
+    try:
+        client.server.ban_manager.remove_hdidban(hdid)
+    except ServerError:
+        raise
+    logger.log_server('Unbanned {}.'.format(hdid), client)
+    client.send_host_message('Unbanned {}'.format(hdid))
 
 def ooc_cmd_getip(client, arg):
 	if not client.is_mod:


### PR DESCRIPTION
HDID bans introduced. IP banning changed. Two new OOC commands introduced, two changed.

/ban will now attempt to find the HDID of the IP in question. If it cannot find one, it will tell the user. In either case, it will log the ban and the method of ban along with the IP and HDID if possible.

/banhdid will ban a user's HDID and attempt to find a connected user with that HDID. If it finds said user, it adds their IP to the ban list and disconnects them.

HDID bans have their own list within the file structure.

/unbanhdid will unban a user's HDID and remove it from the HDID ban file. It will tell the user when it succeeds.
/unban will also output a message upon success.