### PR TITLE
Server Polling 2: Electric Boogaloo

### DIFF
--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -24,3 +24,5 @@ debug: false
 
 area_locking_enabled: false
 rp_mode_enabled: false
+
+poll_slots: 10

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -238,7 +238,7 @@ class ClientManager:
                 if self.is_mod:
                     info += ' ({})'.format(c.get_hdid())
             return info
-		
+
         def get_area_ip(self, area_id):
             info = ''
             try:
@@ -252,7 +252,7 @@ class ClientManager:
                 if self.is_mod:
                     info += ' ({})'.format(c.get_ip())
             return info
-		
+
         def get_char_name(self):
             if self.char_id == -1:
                 return 'CHAR_SELECT'
@@ -268,10 +268,6 @@ class ClientManager:
 
         def can_call_mod(self):
             return (time.time() * 1000.0 - self.mod_call_time) > 0
-			
-        def current_poll(self, poll):
-            Poll = type("Poll", (object,), dict())
-            poll = Poll()
     
         def vote_poll(self, value):
             allowed_values = ('yes', 'no')

--- a/server/commands.py
+++ b/server/commands.py
@@ -722,25 +722,25 @@ def ooc_cmd_vote(client, arg):
             client.send_host_message('Current Available Commands: add, remove, list, info, yes, no. USAGE: /vote [command] [poll]')
     elif arg == "add":
         if not client.is_mod:
-            logger.log_serverpoll('Client \'{}\' attempting to add poll without credentials.'.format(ip))
+            logger.log_serverpoll('\'{}\' on character \'{}\' at ip \'{}\' attempting to add poll without credentials.'.format(client.name, client.get_char_name(), ip))
             raise ClientError('You must be authorized to do that.')
         else:
             if mod1 == None:
                 raise ClientError('You must specify a poll to add.')
             else:
-                logger.log_serverpoll('Client \'{}\' attempting to add poll \'{}\'.'.format(ip, mod1))
+                logger.log_serverpoll('\'{}\' on character \'{}\' at ip \'{}\' attempting to add poll \'{}\'.'.format(client.name, client.get_char_name(), ip, mod1))
                 client.server.serverpoll_manager.add_poll(mod1)
                 client.send_host_message('Poll \'{}\' added successfully.'.format(mod1))
     elif arg == "remove":
         if not client.is_mod:
-            logger.log_serverpoll('Client \'{}\' attempting to remove a poll without credentials.'.format(ip, mod1))
+            logger.log_serverpoll('\'{}\' on character \'{}\' at ip \'{}\' attempting to remove a poll without credentials.'.format(client.name, client.get_char_name(), ip, mod1))
             raise ClientError('You must be authorized to do that.')
         else:
             if mod1 == None:
                 raise ClientError('You must specify a poll to remove.')
             else:
                 try:
-                    logger.log_serverpoll('Client \'{}\' attempting to remove \'{}\'.'.format(ip, mod1))
+                    logger.log_serverpoll('\'{}\' on character \'{}\' at ip \'{}\' attempting to remove \'{}\'.'.format(client.name, client.get_char_name(), ip, mod1))
                     client.server.serverpoll_manager.remove_poll(mod1)
                 except FileNotFoundError:
                     raise ClientError('There is currently no vote list. Someone fucked up.')
@@ -755,13 +755,13 @@ def ooc_cmd_vote(client, arg):
         client.send_host_message("Current list of polls: {}".format(poll))
     elif arg == "info":
         if not client.is_mod:
-            logger.log_serverpoll('Client \'{}\' attempting to check poll information without credentials.'.format(ip))
+            logger.log_serverpoll('\'{}\' on character \'{}\' at ip \'{}\' attempting to check poll information without credentials.'.format(client.name, client.get_char_name(), ip))
             raise ClientError('You must be authorized to do that.')
         elif mod1 == None:
             raise ClientError('You must supply a poll to gather info about.')
         else:
             try:
-                logger.log_serverpoll('Client \'{}\' opened the log for poll \'{}\'.'.format(ip, mod1))
+                logger.log_serverpoll('\'{}\' on character \'{}\' at ip \'{}\' opened the log for poll \'{}\'.'.format(client.name, client.get_char_name(), ip, mod1))
                 info = client.server.serverpoll_manager.get_votelist(mod1)
                 info = "Activity log for poll \'{}\'.\n{}".format(mod1, info)
                 info = info.replace('],', '],\n')
@@ -770,7 +770,7 @@ def ooc_cmd_vote(client, arg):
                 raise
     elif arg == "yes" or arg == "no":
         try:
-            logger.log_serverpoll('Client \'{}\' attempting to vote \'{}\' on poll \'{}\'.'.format(ip, arg, mod1))
+            logger.log_serverpoll('\'{}\' on character \'{}\' at ip \'{}\' attempting to vote \'{}\' on poll \'{}\'.'.format(client.name, client.get_char_name(), ip, arg, mod1))
             client.server.serverpoll_manager.load_votelist(mod1)
             client.server.serverpoll_manager.add_vote(arg, ip, hdid)
         except FileNotFoundError:

--- a/server/commands.py
+++ b/server/commands.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import random
-
 from server import logger
 from server.exceptions import ClientError, ServerError, ArgumentError, AreaError
 
@@ -180,8 +179,7 @@ def ooc_cmd_getareas(client, arg):
 def ooc_cmd_doc(client, arg):
     if len(arg) == 0:
         client.send_host_message('Document: {}'.format(client.area.doc))
-        logger.log_server(
-            '[{}][{}]Requested document. Link: {}'.format(client.area.id, client.get_char_name(), client.area.doc))
+        logger.log_server('[{}][{}]Requested document. Link: {}'.format(client.area.id, client.get_char_name(), client.area.doc))
     else:
         client.area.change_doc(arg)
         client.area.send_host_message('{} changed the doc link.'.format(client.get_char_name()))
@@ -192,10 +190,8 @@ def ooc_cmd_cleardoc(client, arg):
     if len(arg) != 0:
         raise ArgumentError('This command has no arguments.')
     client.area.send_host_message('{} cleared the doc link.'.format(client.get_char_name()))
-    logger.log_server('[{}][{}]Cleared document. Old link: {}'
-                      .format(client.area.id, client.get_char_name(), client.area.doc))
+    logger.log_server('[{}][{}]Cleared document. Old link: {}'.format(client.area.id, client.get_char_name(), client.area.doc))
     client.area.change_doc()
-
 
 def ooc_cmd_status(client, arg):
     if len(arg) == 0:
@@ -204,11 +200,9 @@ def ooc_cmd_status(client, arg):
         try:
             client.area.change_status(arg)
             client.area.send_host_message('{} changed status to {}.'.format(client.get_char_name(), client.area.status))
-            logger.log_server(
-                '[{}][{}]Changed status to {}'.format(client.area.id, client.get_char_name(), client.area.status))
+            logger.log_server('[{}][{}]Changed status to {}'.format(client.area.id, client.get_char_name(), client.area.status))
         except AreaError:
             raise
-
 
 
 def ooc_cmd_pm(client, arg):
@@ -272,7 +266,6 @@ def ooc_cmd_charselect(client, arg):
     else:
         client.char_select()
 
-
 def ooc_cmd_randomchar(client, arg):
     if len(arg) != 0:
         raise ArgumentError('This command has no arguments.')
@@ -286,14 +279,12 @@ def ooc_cmd_randomchar(client, arg):
         raise
     client.send_host_message('Randomly switched to {}'.format(client.get_char_name()))
 
-
 def ooc_cmd_help(client, arg):
     if len(arg) != 0:
         raise ArgumentError('This command has no arguments.')
     help_url = 'https://github.com/Attorney-Online-Engineering-Task-Force/tsuserver3'
     help_msg = 'Available commands, source code and issues can be found here: {}'.format(help_url)
     client.send_host_message(help_msg)
-
 
 def ooc_cmd_pos(client, arg):
     if len(arg) == 0:
@@ -305,7 +296,6 @@ def ooc_cmd_pos(client, arg):
         except ClientError:
             raise
         client.send_host_message('Position changed.')
-
 
 def ooc_cmd_bg(client, arg):
     if len(arg) == 0:
@@ -319,12 +309,12 @@ def ooc_cmd_bg(client, arg):
     client.area.send_host_message('{} changed the background to {}.'.format(client.get_char_name(), arg))
     logger.log_server('[{}][{}]Changed background to {}'.format(client.area.id, client.get_char_name(), arg), client)
 
-def ooc_cmd_bglock(client,arg):
+def ooc_cmd_bglock(client, arg):
     if not client.is_mod:
         raise ClientError('You must be authorized to do that.')
     if len(arg) != 0:
         raise ArgumentError('This command has no arguments.')
-    if client.area.bg_lock  == "true":
+    if client.area.bg_lock == "true":
         client.area.bg_lock = "false"
     else:
         client.area.bg_lock = "true"
@@ -338,6 +328,7 @@ def ooc_cmd_bglist(client, arg):
         bgs += '\r\n' + bg
 
     client.send_host_message(bgs)
+
 
 def ooc_cmd_motd(client, arg):
     if len(arg) != 0:
@@ -358,8 +349,7 @@ def ooc_cmd_roll(client, arg):
         val = 6
     roll = random.randint(1, val)
     client.area.send_host_message('{} rolled {} out of {}.'.format(client.get_char_name(), roll, val))
-    logger.log_server(
-        '[{}][{}]Used /roll and got {} out of {}.'.format(client.area.id, client.get_char_name(), roll, val))
+    logger.log_server('[{}][{}]Used /roll and got {} out of {}.'.format(client.area.id, client.get_char_name(), roll, val))
 
 
 def ooc_cmd_coinflip(client, arg):
@@ -377,8 +367,7 @@ def ooc_cmd_currentmusic(client, arg):
         raise ArgumentError('This command has no arguments.')
     if client.area.current_music == '':
         raise ClientError('There is no music currently playing.')
-    client.send_host_message('The current music is {} and was played by {}.'.format(client.area.current_music,
-                                                                                    client.area.current_music_player))
+    client.send_host_message('The current music is {} and was played by {}.'.format(client.area.current_music, client.area.current_music_player))
 
 
 def ooc_cmd_login(client, arg):
@@ -391,6 +380,7 @@ def ooc_cmd_login(client, arg):
     client.send_host_message('Logged in as a moderator.')
     logger.log_server('Logged in as moderator.', client)
     client.in_rp = False
+
 
 def ooc_cmd_kick(client, arg):
     if not client.is_mod:
@@ -406,8 +396,9 @@ def ooc_cmd_kick(client, arg):
     else:
         client.send_host_message("No targets found.")
 
+
 def ooc_cmd_ban(client, arg):
-    #Set Variables to None for Logging Purposes.
+    # Set Variables to None for Logging Purposes.
     ip = None
     hdid = None
     if not client.is_mod:
@@ -436,8 +427,9 @@ def ooc_cmd_ban(client, arg):
         client.send_host_message('Added {} to the banlist.'.format(ip))
         logger.log_server('Banned {} by IP. Could not locate client HDID.'.format(ip), client)
 
+
 def ooc_cmd_banhdid(client, arg):
-    #Set Variables to None for Logging Purposes.
+    # Set Variables to None for Logging Purposes.
     ip = None
     hdid = None
     if not client.is_mod:
@@ -467,6 +459,7 @@ def ooc_cmd_banhdid(client, arg):
         client.send_host_message('Added {} to the banlist.'.format(hdid))
         logger.log_server('Banned {} at HDID. Could not locate client ip.'.format(hdid), client)
 
+
 def ooc_cmd_unban(client, arg):
     if not client.is_mod:
         raise ClientError('You must be authorized to do that.')
@@ -479,6 +472,7 @@ def ooc_cmd_unban(client, arg):
         raise
     logger.log_server('Unbanned {}.'.format(ip), client)
     client.send_host_message('Unbanned {}'.format(ip))
+
 
 def ooc_cmd_unbanhdid(client, arg):
     if not client.is_mod:
@@ -493,14 +487,16 @@ def ooc_cmd_unbanhdid(client, arg):
     logger.log_server('Unbanned {}.'.format(hdid), client)
     client.send_host_message('Unbanned {}'.format(hdid))
 
+
 def ooc_cmd_getip(client, arg):
     if not client.is_mod:
-        raise ClientError ('You must be authorized to do that.')
+        raise ClientError('You must be authorized to do that.')
     if len(arg) == 0:
         try:
             client.send_area_ip(client.area.id)
         except AreaError:
             raise
+
 
 def ooc_cmd_getips(client, arg):
     if not client.is_mod:
@@ -508,6 +504,7 @@ def ooc_cmd_getips(client, arg):
     if len(arg) != 0:
         raise ArgumentError('This command takes no arguments.')
     client.send_all_area_ip()
+
 
 def ooc_cmd_gethdid(client, arg):
     if not client.is_mod:
@@ -518,12 +515,14 @@ def ooc_cmd_gethdid(client, arg):
         except AreaError:
             raise
 
+
 def ooc_cmd_gethdids(client, arg):
     if not client.is_mod:
         raise ClientError('You must be authorized to do that.')
     if len(arg) != 0:
         raise ArgumentError('This command takes no arguments.')
     client.send_all_area_hdid()
+
 
 def ooc_cmd_play(client, arg):
     if not client.is_mod:
@@ -533,6 +532,7 @@ def ooc_cmd_play(client, arg):
     client.area.play_music(arg, client.char_id, -1)
     client.area.add_music_playing(client, arg)
     logger.log_server('[{}][{}]Changed music to {}.'.format(client.area.id, client.get_char_name(), arg), client)
+
 
 def ooc_cmd_mute(client, arg):
     if not client.is_mod:
@@ -548,6 +548,7 @@ def ooc_cmd_mute(client, arg):
         client.send_host_message('Muted {} existing client(s).'.format(len(targets)))
     else:
         client.send_host_message("No targets found.")
+
 
 def ooc_cmd_unmute(client, arg):
     if not client.is_mod:
@@ -567,6 +568,7 @@ def ooc_cmd_unmute(client, arg):
     else:
         client.send_host_message("No targets found.")
 
+
 def ooc_cmd_oocmute(client, arg):
     if not client.is_mod:
         raise ClientError('You must be authorized to do that.')
@@ -581,6 +583,7 @@ def ooc_cmd_oocmute(client, arg):
         client.send_host_message('Muted {} existing client(s).'.format(len(targets)))
     else:
         client.send_host_message("No targets found.")
+
 
 def ooc_cmd_oocunmute(client, arg):
     if not client.is_mod:
@@ -599,6 +602,7 @@ def ooc_cmd_oocunmute(client, arg):
         client.send_host_message('Unmuted {} existing client(s).'.format(len(targets)))
     else:
         client.send_host_message("No targets found.")
+
 
 def ooc_cmd_rpmode(p_client, arg):
     if not p_client.server.config['rp_mode_enabled']:
@@ -622,6 +626,7 @@ def ooc_cmd_rpmode(p_client, arg):
     else:
         p_client.send_host_message('Invalid argument! Valid arguments: on, off. Your argument: ' + arg)
 
+
 def ooc_cmd_lock(client, arg):
     if not client.server.config['area_locking_enabled']:
         client.send_host_message('Area locking is disabled in this server!')
@@ -633,12 +638,14 @@ def ooc_cmd_lock(client, arg):
     client.area.current_locker = client
     client.area.send_host_message('Area locked!')
 
+
 def ooc_cmd_unlock(client, arg):
     if client.area.current_locker is client:
         client.area.is_locked = False
         client.send_host_message('Area unlocked!')
     else:
         client.send_host_message('You did not lock this area!')
+
 
 def ooc_cmd_eviswap(client, arg):
     args = arg.split()
@@ -672,9 +679,11 @@ def ooc_cmd_eviswap(client, arg):
         client.send_host_message("Invalid argument 2!")
         return
 
-    client.area.evidence_list[evi1], client.area.evidence_list[evi2] = client.area.evidence_list[evi2], client.area.evidence_list[evi1]
+    client.area.evidence_list[evi1], client.area.evidence_list[evi2] = client.area.evidence_list[evi2], \
+                                                                       client.area.evidence_list[evi1]
 
     client.area.broadcast_evidence_list()
+
 
 def ooc_cmd_mutepm(client, arg):
     if len(arg) != 0:
@@ -685,16 +694,88 @@ def ooc_cmd_mutepm(client, arg):
     else:
         client.send_host_message('You are now receiving PMs')
 
+
 def ooc_cmd_vote(client, arg):
-    if len(arg) > 0:
+    # Set up a variable so we can refer to it later.
+    mod1 = None
+    ip = client.get_ip()
+    hdid = client.get_hdid()
+
+    # Split up 'arg' into components we can use.
+    try:
+        args = arg.split()
+    except IndexError:
+        raise
+    # Probably use dict to make this a lot neater and not a mess of fucking if statements.
+    if len(args) == 1:
+        arg = args[0]
+    if len(args) == 2:
+        arg = args[0]
+        mod1 = args[1]
+    if len(args) > 2:
+        raise ClientError('You may only specify a maximum of 2 arguments')
+
+    if len(args) == 0:
+        if not client.is_mod:
+            client.send_host_message('Current Available Commands: list, yes, no. USAGE: /vote [command] [poll]')
+        else:
+            client.send_host_message('Current Available Commands: add, remove, list, info, yes, no. USAGE: /vote [command] [poll]')
+    elif arg == "add":
+        if not client.is_mod:
+            logger.log_serverpoll('Client \'{}\' attempting to add poll without credentials.'.format(ip))
+            raise ClientError('You must be authorized to do that.')
+        else:
+            if mod1 == None:
+                raise ClientError('You must specify a poll to add.')
+            else:
+                logger.log_serverpoll('Client \'{}\' attempting to add poll \'{}\'.'.format(ip, mod1))
+                client.server.serverpoll_manager.add_poll(mod1)
+                client.send_host_message('Poll \'{}\' added successfully.'.format(mod1))
+    elif arg == "remove":
+        if not client.is_mod:
+            logger.log_serverpoll('Client \'{}\' attempting to remove a poll without credentials.'.format(ip, mod1))
+            raise ClientError('You must be authorized to do that.')
+        else:
+            if mod1 == None:
+                raise ClientError('You must specify a poll to remove.')
+            else:
+                try:
+                    logger.log_serverpoll('Client \'{}\' attempting to remove \'{}\'.'.format(ip, mod1))
+                    client.server.serverpoll_manager.remove_poll(mod1)
+                except FileNotFoundError:
+                    raise ClientError('There is currently no vote list. Someone fucked up.')
+                except TypeError:
+                    raise ClientError('Something about what you input caused a TypeError.')
+                if mod1 == "all":
+                    client.send_host_message('All polls removed successfully.'.format(mod1))
+                else:
+                    client.send_host_message('Poll \'{}\' removed successfully.'.format(mod1))
+    elif arg == "list":
+        poll = client.server.serverpoll_manager.show_poll_list()
+        client.send_host_message("Current list of polls: {}".format(poll))
+    elif arg == "info":
+        if not client.is_mod:
+            logger.log_serverpoll('Client \'{}\' attempting to check poll information without credentials.'.format(ip))
+            raise ClientError('You must be authorized to do that.')
+        elif mod1 == None:
+            raise ClientError('You must supply a poll to gather info about.')
+        else:
+            try:
+                logger.log_serverpoll('Client \'{}\' opened the log for poll \'{}\'.'.format(ip, mod1))
+                info = client.server.serverpoll_manager.get_votelist(mod1)
+                info = "Activity log for poll \'{}\'.\n{}".format(mod1, info)
+                info = info.replace('],', '],\n')
+                client.send_host_message(info)
+            except:
+                raise
+    elif arg == "yes" or arg == "no":
         try:
-            hdid = client.get_hdid()
-            ip = client.server.client_manager.get_ip_by_hdid(hdid)
-            if client.server.serverpoll_manager.has_voted(hdid, ip):
-                raise ClientError('You have already voted.')
-            client.vote_poll(arg)
-            client.server.serverpoll_manager.add_votelist(hdid, ip)
-            client.send_host_message('Thank you for voting.')
-            logger.log_serverpoll('[SERVERPOLL][{}][{}] has voted {}.'.format(ip, hdid, arg), client)
-        except ClientError:
+            logger.log_serverpoll('Client \'{}\' attempting to vote \'{}\' on poll \'{}\'.'.format(ip, arg, mod1))
+            client.server.serverpoll_manager.load_votelist(mod1)
+            client.server.serverpoll_manager.add_vote(arg, ip, hdid)
+        except FileNotFoundError:
+            raise
+        except ValueError:
+            raise
+        except IndexError:
             raise

--- a/server/serverpoll_manager.py
+++ b/server/serverpoll_manager.py
@@ -16,36 +16,150 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import yaml
+import time
 
+from server import logger
 from server.exceptions import ServerError
 
-class ServerpollManager:
-    def __init__(self):
-        self.vote = []
-        self.load_votelist()
 
-    def load_votelist(self):
+class ServerpollManager:
+    def __init__(self, server):
+        self.server = server
+        self.poll_list = []
+        self.poll_display = []
+        self.current_poll = []
+        self.load_poll_list()
+        self.vote = []
+        self.slots = []
+
+    #        self.load_slots
+
+    def load_poll_list(self):
         try:
-            with open('storage/votelist.json', 'r') as votelist_file:
-                self.vote = json.load(votelist_file)
+            with open('storage/poll/polllist.json', 'r') as poll_list_file:
+                self.poll_list = json.load(poll_list_file)
         except FileNotFoundError:
             return
         except ValueError:
             return
 
-    def write_votelist(self):
-        with open('storage/votelist.json', 'w') as votelist_file:
-            json.dump(self.vote, votelist_file)
+    def write_poll_list(self):
+        with open('storage/poll/polllist.json', 'w') as poll_list_file:
+            json.dump(self.poll_list, poll_list_file)
 
-    def add_votelist(self, ip, hdid):
-        if ip not in self.vote:
-            self.vote.append(ip)
-        if hdid not in self.vote:
-            self.vote.append(hdid)
+    def show_poll_list(self):
+        output = [item[0] for item in self.poll_list]
+        return output
+
+    def add_poll(self, value):
+        test = time.strftime('%y-%m-%d %H%M-%S')
+        if not ([item for item in self.poll_list if item[0] == value]):
+            if len(self.poll_list) < self.server.config['poll_slots']:
+                self.poll_list.append([value, test])
+                tmp = time.strftime('%y-%m-%d %H:%M:%S')
+                newfile = {
+                    'name': value,
+                    'voteyes': 0,
+                    'voteno': 0,
+                    'created': tmp,
+                    'log': []
+                }
+                with open('storage/poll/{} \'{}\'.yaml'.format(test, value), 'w') as file:
+                    yaml.dump(newfile, file, default_flow_style=False)
+                    logger.log_serverpoll('Poll \'{}\' added successfully.'.format(value))
+            else:
+                logger.log_serverpoll('Failed to add poll. Reason: The poll queue is full.')
+                raise ServerError('The Poll Queue is full!')
         else:
-            raise ServerError('You have already voted.')
-        self.write_votelist()
+            logger.log_serverpoll('Failed to add poll. Reason: This poll already exists.')
+            raise ServerError('This poll already exists.')
+        self.write_poll_list()
 
+    def remove_poll(self, value):
+        if ([i for i in self.poll_list if i[0] == "{}".format(value)]):
+            self.poll_list = [i for i in self.poll_list if i[0] != "{}".format(value)]
+            logger.log_serverpoll('Poll \'{}\' removed.'.format(value))
+        elif value == "all":
+            self.poll_list = []
+            logger.log_serverpoll('All polls removed.')
+        else:
+            logger.log_serverpoll('Poll removal failed. Reason: The specified poll does not exist.')
+            raise ServerError('The specified poll does not exist.')
+        self.write_poll_list()
 
-    def has_voted(self, ip, hdid):
-        return ip and hdid in self.vote
+    def poll_exists(self, value):
+        if [i for i in self.poll_list if i[0] == "{}".format(value)]:
+            return True
+        else:
+            return False
+
+    def load_votelist(self, value):
+        if [i for i in self.poll_list if i[0] == "{}".format(value)]:
+            poll_selected = [i[1] for i in self.poll_list if i[0] == "{}".format(value)]
+            self.current_poll = ('{} \'{}\''.format("".join(poll_selected), value))
+        else:
+            return
+
+    def get_votelist(self, value):
+        try:
+            if [i for i in self.poll_list if i[0] == "{}".format(value)]:
+                poll_selected = [i[1] for i in self.poll_list if i[0] == "{}".format(value)]
+                output = ('{} \'{}\''.format("".join(poll_selected), value))
+                stream = open('storage/poll/{}.yaml'.format(output), 'r')
+                stream2 = yaml.load(stream)
+                log = stream2['log']
+                return log
+            else:
+                return None
+        except FileNotFoundError:
+            raise ServerError('The specified poll has no file associated with it.')
+        except IndexError:
+            raise ServerError('The poll list is currently empty.')
+
+    def add_vote(self, vote, ip, hdid):
+        try:
+            # Open that shit up and extract the important parts.
+            stream = open('storage/poll/{}.yaml'.format(self.current_poll), 'r')
+            self.vote = yaml.load(stream)
+            log = self.vote['log']
+            if [item for item in log if item[1] == ip] or [item for item in log if item[2] == hdid]:
+                # Now to log their failed vote
+                tmp = time.strftime('%y-%m-%d %H:%M:%S')
+                self.vote['log'] += (['FAILED VOTE', tmp, ip, hdid],)
+                self.write_votelist()
+                logger.log_serverpoll('Vote \'{}\' failed by {}. Reason: Already voted.'.format(vote, ip))
+                raise ServerError('You have already voted in this poll.')
+            else:
+                # If they aren't a filthy rigger, they should get to this point.
+                if vote == "yes":
+                    self.vote['voteyes'] += 1
+                elif vote == "no":
+                    self.vote['voteno'] += 1
+            if not [item for item in log if item[1] == ip] or not [item for item in log if item[2] == hdid]:
+                tmp = time.strftime('%y-%m-%d %H:%M:%S')
+                self.vote['log'] += ([tmp, ip, hdid],)
+            self.write_votelist()
+            logger.log_serverpoll('Vote \'{}\' added successfully by {}'.format(vote, ip))
+            raise ServerError('Vote added successfully.')
+        except FileNotFoundError:
+            logger.log_serverpoll('Vote \'{}\' failed by {}. Reason: FileNotFound error'.format(vote, ip))
+            raise ServerError('The specified poll does not have a file associated with it.')
+        except IndexError:
+            # todo: A bit redundant. There's probably a better way.
+            if vote == "yes":
+                self.vote['voteyes'] += 1
+            elif vote == "no":
+                self.vote['voteno'] += 1
+            tmp = time.strftime('%y-%m-%d %H:%M:%S')
+            self.vote['log'] += ([tmp, ip, hdid],)
+            self.write_votelist()
+            logger.log_serverpoll('Vote \'{}\' added successfully by {}'.format(vote, ip))
+            raise ServerError('Vote added successfully.')
+
+    def write_votelist(self):
+        with open('storage/poll/{}.yaml'.format(self.current_poll), 'w') as votelist_file:
+            yaml.dump(self.vote, votelist_file, default_flow_style=False)
+            #           Clear variables to default now that you're done writing.
+            self.current_poll = []
+            self.vote = []

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -35,7 +35,7 @@ class TsuServer3:
         self.client_manager = ClientManager(self)
         self.area_manager = AreaManager(self)
         self.ban_manager = BanManager()
-        self.serverpoll_manager = ServerpollManager()
+        self.serverpoll_manager = ServerpollManager(self)
         self.software = 'tsuserver3'
         self.release = 3
         self.major_version = 1


### PR DESCRIPTION
Adds a /poll command to the server.

/poll add [poll] : Adds the specified poll to the queue and generates a file and logs the action. Available only to logged-in mods. Polls are currently only able to be one word long.

/poll remove [poll] : Removes the specified poll to the queue and generates a file and logs the action. Available only to logged-in mods. Specify "all" to remove all polls.

/poll list : Lists the currently-active polls.

/poll yes [poll] : Adds a 'yes' vote to the specified poll if it exists and you have not already voted.
/poll no [Poll] : Adds a 'no' vote to the specified poll if it exists and you have not already voted.

/poll info [poll] : Supplies basic information about the specified poll. Yes/No votes, and the hdid/ips who have voted, their votes, and when they voted.

---

serverpoll.log files are generated to log the actions of the users and can be checked for greater detail on actions, such as the opening of polls, removal, addition, and the OOC/Character Name being used by those in question at the time.

A configurable maximum to server polls has been added to config.yaml. It defaults to ten.